### PR TITLE
update PrimaryIdentifier to use DeviceId or LinkId or SiteId itself

### DIFF
--- a/device/aws-networkmanager-device.json
+++ b/device/aws-networkmanager-device.json
@@ -95,7 +95,6 @@
     "/properties/GlobalNetworkId"
   ],
   "primaryIdentifier": [
-    "/properties/GlobalNetworkId",
     "/properties/DeviceId"
   ],
   "additionalIdentifiers": [

--- a/link/aws-networkmanager-link.json
+++ b/link/aws-networkmanager-link.json
@@ -86,7 +86,6 @@
     "/properties/SiteId"
   ],
   "primaryIdentifier": [
-    "/properties/GlobalNetworkId",
     "/properties/LinkId"
   ],
   "additionalIdentifiers": [

--- a/site/aws-networkmanager-site.json
+++ b/site/aws-networkmanager-site.json
@@ -75,7 +75,6 @@
     "/properties/GlobalNetworkId"
   ],
   "primaryIdentifier": [
-    "/properties/GlobalNetworkId",
     "/properties/SiteId"
   ],
   "additionalIdentifiers": [


### PR DESCRIPTION
**Description of changes:**
update PrimaryIdentifier to use DeviceId or LinkId or SiteId itself
This is for using `Ref` to use DeviceId in other resources, instead of using `getAtt`

**Testing**
After the change, ran the following command to submit and set the most updated version to Cloudformation :
`cfn generate` 
`mvn clean verify --no-transfer-progress`
` cfn submit --set-default`   
Then tested in Cloudformation console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
