### PR TITLE
Revert "update PrimaryIdentifier to use DeviceId or LinkId or SiteId itself"

### DIFF
--- a/device/aws-networkmanager-device.json
+++ b/device/aws-networkmanager-device.json
@@ -95,6 +95,7 @@
     "/properties/GlobalNetworkId"
   ],
   "primaryIdentifier": [
+    "/properties/GlobalNetworkId",
     "/properties/DeviceId"
   ],
   "additionalIdentifiers": [

--- a/link/aws-networkmanager-link.json
+++ b/link/aws-networkmanager-link.json
@@ -86,6 +86,7 @@
     "/properties/SiteId"
   ],
   "primaryIdentifier": [
+    "/properties/GlobalNetworkId",
     "/properties/LinkId"
   ],
   "additionalIdentifiers": [

--- a/site/aws-networkmanager-site.json
+++ b/site/aws-networkmanager-site.json
@@ -75,6 +75,7 @@
     "/properties/GlobalNetworkId"
   ],
   "primaryIdentifier": [
+    "/properties/GlobalNetworkId",
     "/properties/SiteId"
   ],
   "additionalIdentifiers": [


### PR DESCRIPTION
Reverts aws-cloudformation/aws-cloudformation-resource-providers-networkmanager#12

As ReadHandler requires GlobalNetworkId as a required parameter, and only primaryIdentifier is available in READ call.